### PR TITLE
Feat : 구글 로그인, 카카오 로그인 구현

### DIFF
--- a/src/components/login/GoogleLoginButton.jsx
+++ b/src/components/login/GoogleLoginButton.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import * as S from './SnsLoginButton.style';
+import { useGoogleLogin } from '@react-oauth/google';
+
+const GoogleLoginButton = () => {
+  const navigate = useNavigate();
+
+  const login = useGoogleLogin({
+    onSuccess: tokenResponse => {
+      console.log(tokenResponse);
+      navigate('/signup');
+    },
+  });
+
+  return <S.LoginButton onClick={() => login()}>구글로 계속하기</S.LoginButton>;
+};
+
+export default GoogleLoginButton;

--- a/src/components/login/KakaoLoginButton.jsx
+++ b/src/components/login/KakaoLoginButton.jsx
@@ -1,0 +1,17 @@
+import * as S from './SnsLoginButton.style';
+
+const KakaoLoginButton = () => {
+  const Rest_api_key = import.meta.env.VITE_KAKAO_REST_API_KEAY;
+  const redirect_uri = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+
+  const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${Rest_api_key}&redirect_uri=${redirect_uri}&response_type=code`;
+  const handleLogin = () => {
+    window.location.href = kakaoURL;
+  };
+  return (
+    <>
+      <S.LoginButton onClick={handleLogin}>카카오 로그인</S.LoginButton>
+    </>
+  );
+};
+export default KakaoLoginButton;

--- a/src/components/login/LoginButton.jsx
+++ b/src/components/login/LoginButton.jsx
@@ -1,10 +1,18 @@
+import GoogleLoginButton from './GoogleLoginButton';
+import KakaoLoginButton from './KakaoLoginButton';
 import * as S from './LoginButton.style';
 import LOGIN_BUTTON_LIST from '@/constants/login';
+import { GoogleOAuthProvider } from '@react-oauth/google';
+
 const LoginButton = () => {
+  const clientId = import.meta.env.VITE_GOOGLE_AUTH_CLIENT_ID;
   return (
-    [LOGIN_BUTTON_LIST.map(b => (
-        <S.LoginButton key={b.id}>{b.title}</S.LoginButton>
-      ))]
+    <>
+    <GoogleOAuthProvider clientId={clientId}>
+      <GoogleLoginButton />
+    </GoogleOAuthProvider>
+    <KakaoLoginButton/>
+    </>
   );
 };
 export default LoginButton;

--- a/src/components/login/SnsLoginButton.style.js
+++ b/src/components/login/SnsLoginButton.style.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+import { FONT_SIZE } from '@/constants/size';
+
+
+const LoginButton = styled.button`
+  border-radius: 80px;
+  width: 100%;
+  border: 3px solid #21b69c;
+  color: #21b69c;
+  background-color: white;
+  padding: 20px;
+  margin-bottom: 26px;
+    
+  font-size: ${FONT_SIZE.BASE};
+
+  &:hover {
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    transform: scale(1.05);
+  }
+  
+`;
+
+export { LoginButton};

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -7,9 +7,9 @@ const LoginPage = () => {
     <S.LoginContainer>
       <S.LogoImg src={Logo} />
       <S.ButtonWrap>
-        <S.LinkTo to="/signup">
+
           <LoginButton />
-        </S.LinkTo>
+  
       </S.ButtonWrap>
     </S.LoginContainer>
   );

--- a/src/pages/login/Login.style.js
+++ b/src/pages/login/Login.style.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import theme from '@/theme';
-import { Link } from 'react-router-dom';
+
 
 const LoginContainer = styled.div`
   ${theme.ALIGN.COLUMN_CENTER};
@@ -17,7 +17,6 @@ const ButtonWrap = styled.div`
   width: 70%;
 `;
 
-const LinkTo = styled(Link)`
-`
 
-export { LoginContainer, LogoImg, ButtonWrap, LinkTo };
+
+export { LoginContainer, LogoImg, ButtonWrap};


### PR DESCRIPTION
## 요약

카카오톡 구글 로그인 구현
<br><br>

## 작업 내용
login 구글 & 카카오 로그인 http://localhost:5173/login
<br><br>
<img width="709" alt="image" src="https://github.com/Here-You/FrontEnd/assets/74090222/e24a9b35-b5f7-4752-8529-e14d21bac213">
<br><br>

각각의 로그인 버튼 누르면
<br><br>
<img width="951" alt="image" src="https://github.com/Here-You/FrontEnd/assets/74090222/e7640bf5-97f9-4a0b-9308-418875704e73">
<br><br>
<img width="719" alt="image" src="https://github.com/Here-You/FrontEnd/assets/74090222/b352e72d-562a-4c02-93df-9c182692aa3d">

<br><br>

로그인 완료 후  http://localhost:5173/signup
<br><br>
<img width="718" alt="image" src="https://github.com/Here-You/FrontEnd/assets/74090222/5e3f48de-c061-4491-a0e3-16733ab6c371">


## 관련 이슈

- Close #14 

<br><br>





<br><br>