### PR TITLE
[FEAT] Lazy Loading, Skeleton UI 적용, 기타 스타일 수정, ellipsis 적용.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.0.1",
     "react-intersection-observer": "^9.5.3",
+    "react-lazy-load-image-component": "^1.6.0",
     "react-modal": "^3.16.1",
     "react-router-dom": "^6.21.1",
     "react-slick": "^0.29.0",

--- a/src/components/explore/Preview.jsx
+++ b/src/components/explore/Preview.jsx
@@ -22,7 +22,7 @@ const Preview = ({ data }) => {
           <S.ProfileImg
             height={'fit-content'}
             effect="blur"
-            width={'230px'}
+            width={'25px'}
             src={data?.userImage ? data?.userImage : Logo}
           />
           <S.Nickname>{data?.userName}</S.Nickname>

--- a/src/components/explore/Preview.jsx
+++ b/src/components/explore/Preview.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import * as S from './PreviewStyle.style';
 import Logo from '/images/mypage/MyPageLogo.svg';
 import nonHeart from '/images/signature/ClickedHeart.svg';
+import 'react-lazy-load-image-component/src/effects/blur.css';
 
 const Preview = ({ data }) => {
   const navigate = useNavigate();
@@ -10,10 +11,20 @@ const Preview = ({ data }) => {
   return (
     <>
       <S.PreviewWrap onClick={() => navigate(`/signature/post/${data?._id}`)}>
-        <S.PreviewImg src={data?.image} />
+        <S.PreviewImg
+          height={'fit-content'}
+          effect="blur"
+          width={'140px'}
+          src={data?.image}
+        />
         <S.Title>{data?.title}</S.Title>
         <S.Profile>
-          <S.ProfileImg src={data?.userImage ? data?.userImage : Logo} />
+          <S.ProfileImg
+            height={'fit-content'}
+            effect="blur"
+            width={'230px'}
+            src={data?.userImage ? data?.userImage : Logo}
+          />
           <S.Nickname>{data?.userName}</S.Nickname>
         </S.Profile>
         <S.Info>

--- a/src/components/explore/PreviewStyle.style.js
+++ b/src/components/explore/PreviewStyle.style.js
@@ -1,3 +1,4 @@
+import { LazyLoadImage } from 'react-lazy-load-image-component';
 import styled from 'styled-components';
 
 import { FONT_SIZE } from '@/constants/size';
@@ -11,7 +12,7 @@ const PreviewWrap = styled.div`
   cursor: pointer;
 `;
 
-const PreviewImg = styled.img`
+const PreviewImg = styled(LazyLoadImage)`
   display: flex;
   width: 140px;
   height: 140px;
@@ -33,7 +34,7 @@ const Profile = styled.div`
   justify-content: flex-start;
 `;
 
-const ProfileImg = styled.img`
+const ProfileImg = styled(LazyLoadImage)`
   display: flex;
   width: 25px;
   height: 25px;

--- a/src/components/explore/PreviewStyle.style.js
+++ b/src/components/explore/PreviewStyle.style.js
@@ -22,10 +22,16 @@ const PreviewImg = styled(LazyLoadImage)`
 `;
 
 const Title = styled.div`
-  display: flex;
   font-family: Pretendard-bold;
   font-size: 12px;
   margin: 3px 0px;
+  width: 140px;
+
+  // flex는 말줄임표가 적용이 안됨. (block & inline-block)
+  display: block;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 `;
 
 const Profile = styled.div`
@@ -59,6 +65,8 @@ const Date = styled.div`
 
 const HeartContainer = styled.div`
   ${theme.ALIGN.ROW_CENTER};
+  margin-left: 40px;
+  width: 140px;
   gap: 2px;
 `;
 

--- a/src/components/mate/FollowButton.style.js
+++ b/src/components/mate/FollowButton.style.js
@@ -6,11 +6,12 @@ const Button = styled.button`
   border: none;
   background-color: ${theme.COLOR.MAIN.LIGHT_GREEN};
   color: ${theme.COLOR.MAIN.GRAY};
-  padding: 5px 10px;
+  padding: 5px 18px;
   border-radius: 10px;
   margin-top: 5px;
   margin-left: 10px;
   font-size: 12px;
+  white-space: nowrap;
   cursor: pointer;
 
   &:hover {

--- a/src/components/mate/ManagementProfile.jsx
+++ b/src/components/mate/ManagementProfile.jsx
@@ -23,6 +23,3 @@ const ManagementProfile = ({ profileData }) => {
 };
 
 export default ManagementProfile;
-
-{
-}

--- a/src/components/mate/ManagementProfile.style.js
+++ b/src/components/mate/ManagementProfile.style.js
@@ -4,6 +4,7 @@ import theme from '@/theme';
 
 const CenteredContainer = styled.div`
   ${theme.ALIGN.ROW_CENTER};
+  margin-bottom: 10px;
 `;
 
 const ProfileContainer = styled.div`

--- a/src/components/mate/MateBox.style.js
+++ b/src/components/mate/MateBox.style.js
@@ -21,9 +21,9 @@ const MateDescriptionBox = styled.div`
 `;
 
 const ImageContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  width: 250px;
+  ${theme.ALIGN.ROW_CENTER};
+  width: 300px;
+  height: 100%;
   padding: 10px;
   margin-left: 15px;
   margin-top: 60px;
@@ -31,15 +31,22 @@ const ImageContainer = styled.div`
 `;
 
 const TextBox = styled.div`
+  width: 200px;
   ${theme.ALIGN.ROW_CENTER};
-  align-items: flex-start;
+  justify-content: space-between;
 
   h1 {
-    font-size: 1.4rem;
+    font-size: 0.8rem;
+    margin-bottom: 3px;
+    display: block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   p {
     font-size: 0.8rem;
+    color: ${theme.COLOR.MAIN.GRAY};
   }
 `;
 
@@ -58,13 +65,20 @@ const MateImage = styled.img`
 const SignatureContainer = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100px;
+
   p {
     font-size: 0.8rem;
+    display: block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    color: ${theme.COLOR.MAIN.GRAY};
   }
 `;
 
 const SignatureImage = styled.img`
-  width: 100px;
+  width: 100%;
   height: 100px;
   object-fit: cover;
   border-radius: 5px;

--- a/src/components/mate/skeleton/ManagementProfileSkeleton.jsx
+++ b/src/components/mate/skeleton/ManagementProfileSkeleton.jsx
@@ -1,0 +1,21 @@
+import * as S from './ManagementProfileSkeleton.style';
+
+const ManagementProfileSkeleton = () => {
+  return (
+    <S.CenteredContainer>
+      <S.ProfileContainer>
+        <S.UserImg />
+        <S.TextContainer>
+          <S.UserName />
+          <S.UserNickName />
+          <S.UserBio />
+        </S.TextContainer>
+        <S.Wrapper>
+          <S.Button />
+        </S.Wrapper>
+      </S.ProfileContainer>
+    </S.CenteredContainer>
+  );
+};
+
+export default ManagementProfileSkeleton;

--- a/src/components/mate/skeleton/ManagementProfileSkeleton.style.js
+++ b/src/components/mate/skeleton/ManagementProfileSkeleton.style.js
@@ -1,0 +1,97 @@
+import styled, { keyframes } from 'styled-components';
+
+import theme from '@/theme';
+
+const skeletonGradient = keyframes`
+  0% {
+    background-color: rgba(165, 165, 165, 0.1);
+  }
+  50% {
+    background-color: rgba(165, 165, 165, 0.3);
+  }
+  100% {
+    background-color: rgba(165, 165, 165, 0.1);
+  }
+`;
+
+const CenteredContainer = styled.div`
+  ${theme.ALIGN.ROW_CENTER};
+  margin-bottom: 10px;
+`;
+
+const ProfileContainer = styled.div`
+  ${theme.ALIGN.ROW_CENTER};
+  width: 375px;
+  height: 85px;
+  position: relative;
+  cursor: pointer;
+  border-radius: 20px;
+  background-color: #cccccc;
+  animation: ${skeletonGradient} 1.5s infinite;
+`;
+
+const UserImg = styled.div`
+  width: 45px;
+  height: 45px;
+  border-radius: 45px;
+  border: none;
+  position: absolute;
+  left: 47px;
+  animation: ${skeletonGradient} 1.5s infinite;
+`;
+
+const TextContainer = styled.div`
+  ${theme.ALIGN.COLUMN_CENTER}
+  align-items: flex-start;
+  width: 140px;
+  gap: 3px;
+  position: absolute;
+  left: 110px;
+  top: 10px;
+`;
+
+const UserName = styled.span`
+  height: 20px;
+  width: 80px;
+  background-color: gray;
+  animation: ${skeletonGradient} 1.5s infinite;
+`;
+
+const UserNickName = styled.span`
+  height: 20px;
+  width: 120px;
+  background-color: gray;
+  animation: ${skeletonGradient} 1.5s infinite;
+`;
+
+const UserBio = styled.span`
+  height: 20px;
+  width: 120px;
+  background-color: gray;
+  animation: ${skeletonGradient} 1.5s infinite;
+`;
+
+const Wrapper = styled.div`
+  position: absolute;
+  right: 51px;
+`;
+
+const Button = styled.div`
+  background-color: gray;
+  width: 60px;
+  height: 20px;
+  border-radius: 10px;
+  animation: ${skeletonGradient} 1.5s infinite;
+`;
+
+export {
+  CenteredContainer,
+  ProfileContainer,
+  UserImg,
+  TextContainer,
+  UserName,
+  UserNickName,
+  UserBio,
+  Wrapper,
+  Button,
+};

--- a/src/components/preview/Preview.jsx
+++ b/src/components/preview/Preview.jsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import * as S from './Preview.style';
+import 'react-lazy-load-image-component/src/effects/blur.css';
 
 const Preview = ({ signature }) => {
   const { date, image, title, _id } = signature;
@@ -18,7 +19,12 @@ const Preview = ({ signature }) => {
         <S.DateWrapper>
           <S.Date>{formattedDate}</S.Date>
         </S.DateWrapper>
-        <S.PreviewImg src={image} />
+        <S.PreviewImg
+          src={image}
+          height={'fit-content'}
+          effect="blur"
+          width="150"
+        />
         <S.Title>{title}</S.Title>
         <S.Open to={`/signature/post/${_id}`}>자세히보기</S.Open>
       </S.PreviewWrap>

--- a/src/components/preview/Preview.style.js
+++ b/src/components/preview/Preview.style.js
@@ -1,3 +1,4 @@
+import { LazyLoadImage } from 'react-lazy-load-image-component';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -23,7 +24,7 @@ const Date = styled.div`
   font-size: 12px;
 `;
 
-const PreviewImg = styled.img`
+const PreviewImg = styled(LazyLoadImage)`
   width: 150px;
   height: 150px;
   object-fit: cover;

--- a/src/pages/mate/look/MateLook.jsx
+++ b/src/pages/mate/look/MateLook.jsx
@@ -37,8 +37,7 @@ const MateLookPage = () => {
         <div
           ref={ref}
           style={{
-            width: '40px',
-            height: '20px',
+            width: '20px',
           }}></div>
       </S.CenteredContainer>
       <S.Title>{`${userName}이 사용한 위치 [${location}]을 함께 이용중인 메이트들`}</S.Title>

--- a/src/pages/mate/management/MateManagement.jsx
+++ b/src/pages/mate/management/MateManagement.jsx
@@ -3,20 +3,37 @@ import React, { useState } from 'react';
 import MateContainer from '../MateContainer';
 import * as S from './MateManagement.style';
 import ManagementProfile from '@/components/mate/ManagementProfile';
+import ManagementProfileSkeleton from '@/components/mate/skeleton/ManagementProfileSkeleton';
 import { useMateFollower } from '@/hooks/mate/useMateFollower';
 import { useMateFollowing } from '@/hooks/mate/useMateFollowing';
 
 const MateManagementPage = () => {
-  const { data: follower, loading, error } = useMateFollower();
+  const {
+    data: follower,
+    loading: followerLoading,
+    error: followerError,
+  } = useMateFollower();
+  const {
+    data: following,
+    loading: followingLoading,
+    error: followingError,
+  } = useMateFollowing();
 
-  const { data: following, loadingF, errorF } = useMateFollowing();
-  const [activeTab, setActiveTab] = useState('follower');
-
-  console.log(following, follower);
+  const [activeTab, setActiveTab] = useState('following');
 
   const handleTabClick = tabName => {
     setActiveTab(tabName);
   };
+
+  const followerSkeletons = Array.from(
+    { length: follower?.length },
+    (_, index) => <ManagementProfileSkeleton key={index} />,
+  );
+
+  const followingSkeletons = Array.from(
+    { length: following?.length || 5 },
+    (_, index) => <ManagementProfileSkeleton key={index} />,
+  );
 
   return (
     <MateContainer>
@@ -34,13 +51,26 @@ const MateManagementPage = () => {
       </S.TabContainer>
 
       <S.ProfileContainer>
-        {activeTab === 'follower'
-          ? follower?.map((data, index) => (
-              <ManagementProfile key={index} profileData={data} />
-            ))
-          : following?.map((data, index) => (
+        {/* Follower Loading */}
+        {activeTab === 'follower' && followerLoading && followerSkeletons}
+        {/* Following Loading */}
+        {activeTab === 'following' && followingLoading && followingSkeletons}
+        {/* Follower Not Load */}
+        {activeTab === 'follower' && !followerLoading && (
+          <>
+            {follower?.map((data, index) => (
               <ManagementProfile key={index} profileData={data} />
             ))}
+          </>
+        )}
+        {/* Following Not Load */}
+        {activeTab === 'following' && !followingLoading && (
+          <>
+            {following?.map((data, index) => (
+              <ManagementProfile key={index} profileData={data} />
+            ))}
+          </>
+        )}
       </S.ProfileContainer>
     </MateContainer>
   );

--- a/src/pages/mate/ruleCheck/MateRuleCheck.jsx
+++ b/src/pages/mate/ruleCheck/MateRuleCheck.jsx
@@ -21,7 +21,7 @@ const MateRuleCheckPage = () => {
   return (
     <MateContainer>
       <S.StyledTitle>내가 참여 중인 규칙</S.StyledTitle>
-      {rulesData.map((ruleData, _) => (
+      {rulesData?.map((ruleData, _) => (
         <TeamContainer key={ruleData.id} ruleData={ruleData} />
       ))}
     </MateContainer>

--- a/src/pages/signature/main/MySignaturePage.jsx
+++ b/src/pages/signature/main/MySignaturePage.jsx
@@ -1,9 +1,14 @@
 import * as S from './MySignaturePage.style';
 import Preview from '@/components/preview/Preview';
 import { useSignaturePreview } from '@/hooks/signature/useSignaturePreview ';
+import { ErrorPage } from '@/pages';
 
 const MySignaturePage = () => {
   const { data: signaturePreview, loading, error } = useSignaturePreview();
+
+  if (error) {
+    return <ErrorPage />;
+  }
 
   return (
     <S.PageContainer>

--- a/src/pages/signature/post/SignaturePost.jsx
+++ b/src/pages/signature/post/SignaturePost.jsx
@@ -55,14 +55,6 @@ const SignaturePostPage = () => {
     }
   };
 
-  const handleFollow = async () => {
-    try {
-      toast.success('팔로잉 성공');
-    } catch (e) {
-      toast.error(e.message);
-    }
-  };
-
   if (loading) {
     return <div>로딩 중 입니다..</div>;
   }
@@ -86,14 +78,20 @@ const SignaturePostPage = () => {
                     <S.ProfileImg src={Logo} />
                   )}
                   <S.ProfileDesc>
-                    <h3>{author?.name}</h3>
+                    {author?.name === null ? (
+                      <h3>탈퇴한 회원</h3>
+                    ) : (
+                      <h3>{author?.name}</h3>
+                    )}
                     <date>{header.date}</date>
                   </S.ProfileDesc>
                 </S.ProfileContainer>
-                <FollowButton
-                  initialFollowState={author?.is_followed}
-                  id={author?._id}
-                />
+                {author?.is_followed !== null && (
+                  <FollowButton
+                    initialFollowState={author?.is_followed}
+                    id={author?._id}
+                  />
+                )}
               </S.HeaderContainer>
               <S.TitleContainer>
                 <h1>{header.title}</h1>

--- a/src/pages/signature/write/Editor.style.js
+++ b/src/pages/signature/write/Editor.style.js
@@ -1,3 +1,4 @@
+import { LazyLoadImage } from 'react-lazy-load-image-component';
 import styled from 'styled-components';
 
 import theme from '@/theme';
@@ -149,7 +150,7 @@ const Icon = styled.img`
   background-color: ${theme.COLOR.MAIN.LIGHT_GRAY};
 `;
 
-const Image = styled.img`
+const Image = styled(LazyLoadImage)`
   position: absolute;
   width: 230px;
   height: 230px;

--- a/src/pages/signature/write/Page.jsx
+++ b/src/pages/signature/write/Page.jsx
@@ -6,6 +6,7 @@ import addButton from '/images/addButton.svg';
 import SearchMap from '@/components/searchMap/SearchMap';
 import useHandleImageChange from '@/hooks/image/useHandleImageChange';
 import useSignatureWrite from '@/store/useSignatureWrite';
+import 'react-lazy-load-image-component/src/effects/blur.css';
 
 export default function Page({ image, content }) {
   const { title, pages, updatePage, currentPageIndex, resetData } =
@@ -37,7 +38,14 @@ export default function Page({ image, content }) {
         />
       </S.LocationContainer>
       <S.InputWrap>
-        {image && <S.Image src={`data:image/jpeg;base64,${image}`} />}
+        {image && (
+          <S.Image
+            height={'fit-content'}
+            effect="blur"
+            width={'230px'}
+            src={`data:image/jpeg;base64,${image}`}
+          />
+        )}
         <S.PhotoButton>
           <img src={addButton} alt="Add Button" />
           <S.ImageInput


### PR DESCRIPTION
### 요약
1. mate look page detail 수정
2. Preview Title Ellipsis 처리, Heart 위치 조정
3. Preview Component Profile Component react-lazy-load 간격 수정
4. Siganture Detail Page 유저가 본인인 경우, 탈퇴한 유저인 경우 예외처리
5. MateManagement Skeleton UI/Animation 제작 후 도입
6. Explore Page Blur 처리
7. 시그니처 write page LazyLoadImage 도입

@dydals3440

### 구현 
<img width="613" alt="스크린샷 2024-02-11 오전 1 49 00" src="https://github.com/Here-You/FrontEnd/assets/119042360/5a4b0f8a-4e3c-47f8-8b58-7379e6992fca">

<img width="583" alt="스크린샷 2024-02-11 오전 1 49 29" src="https://github.com/Here-You/FrontEnd/assets/119042360/100aa64d-9b6c-414d-ae45-1ba5dca8f452">

<img width="572" alt="스크린샷 2024-02-11 오전 1 49 43" src="https://github.com/Here-You/FrontEnd/assets/119042360/a59927f0-9d2a-4682-95ee-bd48dae084b0">



### 개발 현황
- [x] mate look page detail 수정
- [x] Preview Title Ellipsis 처리, Heart 위치 조정
- [x] Preview Component Profile Component react-lazy-load 간격 수정
- [x] Siganture Detail Page 유저가 본인인 경우, 탈퇴한 유저인 경우 예외처리
- [x] MateManagement Skeleton UI/Animation 제작 후 도입
- [x] Explore Page Blur 처리
- [x] 시그니처 write page LazyLoadImage 도입

### 참고 사항

