### PR TITLE
[FEAT]: 시그니처 페이지 댓글 대댓글 기능 구현

### DIFF
--- a/src/apis/request/signature.js
+++ b/src/apis/request/signature.js
@@ -66,6 +66,22 @@ const getSignatureComments = (signatureId, take, { pageParam }) => {
   return axiosWithToken.get(url);
 };
 
+// 시그니처 댓글 생성
+const postSignatureComment = ({ signatureId, content }) => {
+  const url = `/api/v1/signature/${signatureId}/comment`;
+  return axiosWithToken.post(url, {
+    content: content,
+  });
+};
+
+// 시그니처 답글 생성
+const postSignatureReComment = ({ signatureId, parentId, content }) => {
+  const url = `/api/v1/signature/${signatureId}/comment/${parentId}`;
+  return axiosWithToken.post(url, {
+    content: content,
+  });
+};
+
 export {
   getMySignaturePreview,
   postNewSignature,
@@ -75,4 +91,6 @@ export {
   likeSignature,
   getLikeList,
   getSignatureComments,
+  postSignatureComment,
+  postSignatureReComment,
 };

--- a/src/apis/request/signature.js
+++ b/src/apis/request/signature.js
@@ -59,6 +59,13 @@ const getLikeList = signatureId => {
   return res;
 };
 
+// 시그니처 댓글 / 답글 불러오기 (무한 스크롤)
+const getSignatureComments = (signatureId, take, { pageParam }) => {
+  const url = `api/v1/signature/${signatureId}/comment?take${take}&cursorId=${pageParam}`;
+  console.log(url);
+  return axiosWithToken.get(url);
+};
+
 export {
   getMySignaturePreview,
   postNewSignature,
@@ -67,4 +74,5 @@ export {
   deleteMySignature,
   likeSignature,
   getLikeList,
+  getSignatureComments,
 };

--- a/src/components/comment/mate/commentInput/MateCommentInput.jsx
+++ b/src/components/comment/mate/commentInput/MateCommentInput.jsx
@@ -1,6 +1,4 @@
 import { useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import toast from 'react-hot-toast';
 
 import * as S from './MateCommentInput.style';
 import { postMateRuleComment } from '@/apis/request/mate';

--- a/src/components/comment/signature/SignatureCommentList.jsx
+++ b/src/components/comment/signature/SignatureCommentList.jsx
@@ -1,31 +1,30 @@
+import { useParams } from 'react-router-dom';
+
 import * as S from './SignatureCommentList.style';
 import SignatureComment from './commentView/SignatureComment';
-
-const PrifleImg =
-  'https://images.unsplash.com/photo-1707638121353-c6853aae5725?w=900&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxlZGl0b3JpYWwtZmVlZHwxOHx8fGVufDB8fHx8fA%3D%3D';
-
-const generateData = count => {
-  const data = [];
-  for (let i = 0; i < count; i++) {
-    data.push({
-      id: i + 1,
-      name: '차다인',
-      image: PrifleImg,
-      text: '댓글 내용',
-      created: '2024-02-07T12:22:00.453Z',
-    });
-  }
-  return data;
-};
-
-const Data = generateData(100);
+import { useGetSignatureComments } from '@/hooks/signature/queries/useGetSignatureComments';
 
 const SignatureCommentList = () => {
+  const { signatureId } = useParams();
+
+  const { data, isLoading, isPending } = useGetSignatureComments(
+    signatureId,
+    2,
+  );
+
+  const signatureComments = data?.pages;
+
   return (
     <S.Container>
-      {Data.map(data => (
-        <SignatureComment key={data.id} data={data} />
-      ))}
+      {signatureComments?.map(comments =>
+        comments?.data?.data?.data?.map(comment => (
+          <SignatureComment key={comment._id} data={comment} />
+        )),
+      )}
+      {/* {Data.map(data => (
+       
+      ))} */}
+      123
     </S.Container>
   );
 };

--- a/src/components/comment/signature/commentInput/SignatureCommentInput.jsx
+++ b/src/components/comment/signature/commentInput/SignatureCommentInput.jsx
@@ -1,15 +1,28 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import * as S from './SignatureInput.style';
+import { postSignatureComment } from '@/apis/request/signature';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const SignatureCommentInput = () => {
-  const textarea = useRef();
-  const placeholder = '댓글을 작성해주세요';
+  const [content, setContent] = useState('');
 
-  const handleResizeHeight = () => {
-    textarea.current.style.height = 'auto';
-    textarea.current.style.height = textarea.current.scrollHeight + 'px';
-  };
+  const { signatureId } = useParams();
+  const queryClient = useQueryClient();
+  const { mutateAsync } = useMutation({
+    mutationFn: postSignatureComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['signatureComments']);
+    },
+    onError: () => {
+      console.error('규칙 나가기 실패:', error);
+      alert(
+        '시그니처 포스트 댓글 작성에 실패했습니다. 나중에 다시 시도해주세요.',
+      );
+    },
+  });
+  const placeholder = '댓글을 작성해주세요';
   const imgUrl =
     'https://images.unsplash.com/photo-1707421940727-ebfb88cd6aa0?q=80&w=2232&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
   return (
@@ -18,10 +31,21 @@ const SignatureCommentInput = () => {
       <S.ContentContainer>
         <S.Input
           placeholder={placeholder}
-          onChange={handleResizeHeight}
-          ref={textarea}
-          rows={1}></S.Input>
-        <S.SubmitButton>저장</S.SubmitButton>
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          rows={1}
+        />
+        <S.SubmitButton
+          onClick={async () => {
+            try {
+              await mutateAsync({ signatureId, content });
+              setContent('');
+            } catch (e) {
+              console.error(e);
+            }
+          }}>
+          저장
+        </S.SubmitButton>
       </S.ContentContainer>
     </S.Container>
   );

--- a/src/components/comment/signature/commentView/SignatureComment.jsx
+++ b/src/components/comment/signature/commentView/SignatureComment.jsx
@@ -1,17 +1,42 @@
 import { format } from 'date-fns';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import * as S from './SignatureComment.style';
 import Pen from '/icons/Pen.svg';
 import Trash from '/icons/Trash.svg';
+import { postSignatureReComment } from '@/apis/request/signature';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const SignatureComment = ({ data }) => {
+  const { signatureId } = useParams();
+
+  const queryClient = useQueryClient();
   const { _id, content, parentId, is_edited, writer, date } = data;
   const formattedEndDate = format(date, 'yyyy-MM-dd HH:mm:ss');
-
+  const [editMode, setEditMode] = useState(false);
+  const [isReplying, setIsReplying] = useState(false);
+  const [replyComment, setReplyComment] = useState('');
+  console.log(replyComment);
   const handleCommentEdit = () => {};
   const handleCommentDelete = () => {};
 
   const indentationLevel = parentId === _id ? 0 : 1;
+  const isParentComment = parentId === _id;
+
+  const handleReplyToggle = () => {
+    setIsReplying(!isReplying);
+  };
+
+  const { mutateAsync: postReComment } = useMutation({
+    mutationFn: postSignatureReComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['signatureComments']);
+    },
+    onError: error => {
+      console.error('답글 작성 실패', error);
+    },
+  });
 
   return (
     <S.Container indentationLevel={indentationLevel}>
@@ -19,16 +44,44 @@ const SignatureComment = ({ data }) => {
       <S.ContentContainer>
         <S.NameContainer>
           <S.Name>{writer?.name}</S.Name>
-          <S.LeftContent>
-            <S.Icon src={Pen} onClick={handleCommentEdit} />
-            <S.Icon src={Trash} onClick={handleCommentDelete} />
-          </S.LeftContent>
+          {isParentComment && (
+            <S.LeftContent>
+              <button onClick={handleReplyToggle}>답글</button>
+              <S.Icon src={Pen} onClick={handleCommentEdit} />
+              <S.Icon src={Trash} onClick={handleCommentDelete} />
+            </S.LeftContent>
+          )}
         </S.NameContainer>
+        <S.Content>{content}</S.Content>
         <S.ContentInner>
-          <S.Content>{content}</S.Content>
-          <h3>{!is_edited === true ? '수정됨' : null}</h3>
+          <S.Content>{formattedEndDate}</S.Content>
+          <S.EditContent>{is_edited === true ? '수정됨' : null}</S.EditContent>
         </S.ContentInner>
-        <S.Content>{formattedEndDate}</S.Content>
+        {isReplying && (
+          <div>
+            <input
+              type="text"
+              placeholder="답글을 작성하세요..."
+              value={replyComment}
+              onChange={e => setReplyComment(e.target.value)}
+            />
+            <button
+              onClick={async () => {
+                try {
+                  postReComment({
+                    signatureId,
+                    parentId,
+                    content: replyComment,
+                  });
+                  setReplyComment('');
+                } catch (e) {
+                  console.log(e);
+                }
+              }}>
+              댓글 작성
+            </button>
+          </div>
+        )}
       </S.ContentContainer>
     </S.Container>
   );

--- a/src/components/comment/signature/commentView/SignatureComment.jsx
+++ b/src/components/comment/signature/commentView/SignatureComment.jsx
@@ -46,7 +46,7 @@ const SignatureComment = ({ data }) => {
           <S.Name>{writer?.name}</S.Name>
           {isParentComment && (
             <S.LeftContent>
-              <button onClick={handleReplyToggle}>답글</button>
+              <S.Button onClick={handleReplyToggle}>답글</S.Button>
               <S.Icon src={Pen} onClick={handleCommentEdit} />
               <S.Icon src={Trash} onClick={handleCommentDelete} />
             </S.LeftContent>
@@ -58,14 +58,14 @@ const SignatureComment = ({ data }) => {
           <S.EditContent>{is_edited === true ? '수정됨' : null}</S.EditContent>
         </S.ContentInner>
         {isReplying && (
-          <div>
-            <input
+          <S.ReplyContainer>
+            <S.Input
               type="text"
               placeholder="답글을 작성하세요..."
               value={replyComment}
               onChange={e => setReplyComment(e.target.value)}
             />
-            <button
+            <S.Button
               onClick={async () => {
                 try {
                   postReComment({
@@ -78,9 +78,9 @@ const SignatureComment = ({ data }) => {
                   console.log(e);
                 }
               }}>
-              댓글 작성
-            </button>
-          </div>
+              답글 작성
+            </S.Button>
+          </S.ReplyContainer>
         )}
       </S.ContentContainer>
     </S.Container>

--- a/src/components/comment/signature/commentView/SignatureComment.jsx
+++ b/src/components/comment/signature/commentView/SignatureComment.jsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import * as S from './SignatureComment.style';
 import Pen from '/icons/Pen.svg';
 import Trash from '/icons/Trash.svg';
+import Logo from '/images/mypage/MyPageLogo.svg';
 import { postSignatureReComment } from '@/apis/request/signature';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -18,6 +19,7 @@ const SignatureComment = ({ data }) => {
   const [isReplying, setIsReplying] = useState(false);
   const [replyComment, setReplyComment] = useState('');
   console.log(replyComment);
+
   const handleCommentEdit = () => {};
   const handleCommentDelete = () => {};
 
@@ -40,7 +42,7 @@ const SignatureComment = ({ data }) => {
 
   return (
     <S.Container indentationLevel={indentationLevel}>
-      <S.Avatar src={writer?.image} />
+      <S.Avatar src={writer?.image ? writer?.image : Logo} />
       <S.ContentContainer>
         <S.NameContainer>
           <S.Name>{writer?.name}</S.Name>

--- a/src/components/comment/signature/commentView/SignatureComment.jsx
+++ b/src/components/comment/signature/commentView/SignatureComment.jsx
@@ -5,28 +5,31 @@ import Pen from '/icons/Pen.svg';
 import Trash from '/icons/Trash.svg';
 
 const SignatureComment = ({ data }) => {
-  const { id, text, created, image, name } = data;
-  const newDate = new Date(created);
-  const formattedEndDate = format(newDate, 'yyyy-MM-dd HH:mm:ss');
+  const { _id, content, parentId, is_edited, writer, date } = data;
+  const formattedEndDate = format(date, 'yyyy-MM-dd HH:mm:ss');
 
-  const handleComemntEdit = () => {};
-
+  const handleCommentEdit = () => {};
   const handleCommentDelete = () => {};
 
+  const indentationLevel = parentId === _id ? 0 : 1;
+
   return (
-    <S.Container>
-      <S.Avatar src={image} />
-      <S.ConentContainer>
+    <S.Container indentationLevel={indentationLevel}>
+      <S.Avatar src={writer?.image} />
+      <S.ContentContainer>
         <S.NameContainer>
-          <S.Name>{name}</S.Name>
+          <S.Name>{writer?.name}</S.Name>
           <S.LeftContent>
-            <S.Icon src={Pen} onClick={handleComemntEdit} />
+            <S.Icon src={Pen} onClick={handleCommentEdit} />
             <S.Icon src={Trash} onClick={handleCommentDelete} />
           </S.LeftContent>
         </S.NameContainer>
-        <S.Content>{text}</S.Content>
+        <S.ContentInner>
+          <S.Content>{content}</S.Content>
+          <h3>{!is_edited === true ? '수정됨' : null}</h3>
+        </S.ContentInner>
         <S.Content>{formattedEndDate}</S.Content>
-      </S.ConentContainer>
+      </S.ContentContainer>
     </S.Container>
   );
 };

--- a/src/components/comment/signature/commentView/SignatureComment.style.js
+++ b/src/components/comment/signature/commentView/SignatureComment.style.js
@@ -31,7 +31,9 @@ const ContentContainer = styled.div`
 `;
 
 const ContentInner = styled.div`
-  ${theme.ALIGN.ROW_CENTER}
+  ${theme.ALIGN.ROW_CENTER};
+  justify-content: flex-start;
+  gap: 10px;
 `;
 
 const Name = styled.p`
@@ -42,6 +44,12 @@ const Name = styled.p`
 const Content = styled.p`
   color: ${theme.COLOR.MAIN.GRAY};
   font-size: ${FONT_SIZE.XS};
+  white-space: pre-line;
+`;
+
+const EditContent = styled.p`
+  color: ${theme.COLOR.MAIN.GRAY};
+  font-size: 0.5rem;
   white-space: pre-line;
 `;
 
@@ -72,6 +80,7 @@ export {
   ContentInner,
   Name,
   Content,
+  EditContent,
   NameContainer,
   LeftContent,
   Icon,

--- a/src/components/comment/signature/commentView/SignatureComment.style.js
+++ b/src/components/comment/signature/commentView/SignatureComment.style.js
@@ -31,6 +31,11 @@ const Button = styled.button`
   padding: 5px 10px;
   border-radius: 10px;
   margin-left: 10px;
+  cursor: pointer;
+
+  &:hover {
+    transform: scale(0.9);
+  }
 `;
 
 const Input = styled.input`
@@ -76,6 +81,7 @@ const EditContent = styled.p`
 const NameContainer = styled.div`
   display: flex;
   flex-direction: row;
+  align-items: center;
   width: 100%;
 `;
 

--- a/src/components/comment/signature/commentView/SignatureComment.style.js
+++ b/src/components/comment/signature/commentView/SignatureComment.style.js
@@ -9,8 +9,10 @@ const Container = styled.div`
   justify-content: center;
   width: 90%;
   padding: 10px;
-
   gap: 20px;
+  margin-left: ${props => (props.indentationLevel ? '40px' : 0)};
+  border-left: ${props => (props.indentationLevel ? '2px solid #ccc' : 'none')};
+  padding-left: ${props => (props.indentationLevel ? '10px' : '0')};
 `;
 
 const Avatar = styled.img`
@@ -19,13 +21,17 @@ const Avatar = styled.img`
   border-radius: 100px;
 `;
 
-const ConentContainer = styled.div`
+const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding-bottom: 20px;
   width: 80%;
   gap: 10px;
   border-bottom: 1px solid ${theme.COLOR.MAIN.LIGHT_GRAY};
+`;
+
+const ContentInner = styled.div`
+  ${theme.ALIGN.ROW_CENTER}
 `;
 
 const Name = styled.p`
@@ -62,7 +68,8 @@ const Icon = styled.img`
 export {
   Container,
   Avatar,
-  ConentContainer,
+  ContentContainer,
+  ContentInner,
   Name,
   Content,
   NameContainer,

--- a/src/components/comment/signature/commentView/SignatureComment.style.js
+++ b/src/components/comment/signature/commentView/SignatureComment.style.js
@@ -21,6 +21,26 @@ const Avatar = styled.img`
   border-radius: 100px;
 `;
 
+const ReplyContainer = styled.div`
+  ${theme.ALIGN.ROW_CENTER};
+`;
+
+const Button = styled.button`
+  background-color: ${theme.COLOR.MAIN.LIGHT_GREEN};
+  border: none;
+  padding: 5px 10px;
+  border-radius: 10px;
+  margin-left: 10px;
+`;
+
+const Input = styled.input`
+  padding: 10px;
+  border: 3px solid ${theme.COLOR.MAIN.LIGHT_GREEN};
+  border-radius: 10px;
+  width: 70%;
+  flex: 1;
+`;
+
 const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -77,6 +97,9 @@ export {
   Container,
   Avatar,
   ContentContainer,
+  Button,
+  Input,
+  ReplyContainer,
   ContentInner,
   Name,
   Content,

--- a/src/components/mate/TeamContainer.jsx
+++ b/src/components/mate/TeamContainer.jsx
@@ -50,9 +50,7 @@ const TeamContainer = ({ ruleData }) => {
         </S.ImgContainer>
         <S.TeammateNum>{memberCnt}명</S.TeammateNum>
       </S.TeamInfoContainer>
-
       <S.TeamTitle>{title}</S.TeamTitle>
-
       <S.ExitContainer>
         <S.ExitButton onClick={handleDeleteRule}>나가기</S.ExitButton>
         <S.WriteDate>{format(updated, 'yy-MM-dd')}</S.WriteDate>

--- a/src/hooks/signature/queries/useGetSignatureComments.js
+++ b/src/hooks/signature/queries/useGetSignatureComments.js
@@ -1,0 +1,21 @@
+import { getSignatureComments } from '@/apis/request/signature';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+const useGetSignatureComments = (signatureId, take) => {
+  return useInfiniteQuery({
+    queryKey: ['signaturesComments', { signatureId }],
+    queryFn: ({ pageParam = 0 }) =>
+      getSignatureComments(signatureId, take, { pageParam }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages, lastPageParam) => {
+      const meta = lastPage?.data?.data?.meta;
+      if (meta && meta.hasNextData) {
+        return meta.cursor;
+      } else {
+        return null;
+      }
+    },
+  });
+};
+
+export { useGetSignatureComments };

--- a/src/hooks/signature/useGetDetail.js
+++ b/src/hooks/signature/useGetDetail.js
@@ -18,7 +18,7 @@ export const useGetDetail = signatureId => {
         const res = await getDetail(signatureId);
         const data = res.data.data;
         const header = data.header;
-        console.log(res.data);
+
         setData(data);
         setLike(header.is_liked);
         setCount(header.like_cnt);

--- a/src/pages/mate/ruleEdit/RuleEdit.jsx
+++ b/src/pages/mate/ruleEdit/RuleEdit.jsx
@@ -59,17 +59,13 @@ const RuleEditPage = () => {
     }));
   };
 
-  const handleSubmitRule = async () => {
-    const postData = {
-      mainTitle: title,
-      rulePairs: rules.map((rule, index) => ({
-        ruleNumber: index + 1,
-        id: rule.id,
-        ruleTitle: rule.ruleTitle,
-        ruleDetail: rule.ruleDetail,
-      })),
-      membersId: selectedMates.map(mate => mate.id),
-    };
+  const handleSubmitRule = () => {
+    const ruleData = postData.rulePairs.map((rule, index) => ({
+      ruleNumber: index + 1,
+      id: rule.id,
+      ruleTitle: rule.ruleTitle,
+      ruleDetail: rule.ruleDetail,
+    }));
 
     const extractMembersId = postData.membersId.map(member => member.id);
 


### PR DESCRIPTION
### 요약
1. 시그니처, 댓글 기능 구현
2. 시그니처, 대댓글 UI 개편
3. 시그니처, 대댓글 기능 구현
4. 시그니처 댓글 / 대댓글 API 연결


### 구현
<Signature 화면 댓글/대댓글 기능 개발>

<img width="699" alt="스크린샷 2024-02-13 오후 1 12 16" src="https://github.com/Here-You/FrontEnd/assets/119042360/6a45ea97-df30-477f-bde1-8cce10b828d3">





### 개발 현황
요약 완성.

### 참고 사항

대댓글/댓글 수정, 삭제는 API 나오면, 바로 작업 예정


