### PR TITLE
[Feat] 시그니처 페이지 대댓글 구현 UX 개선

### DIFF
--- a/src/apis/request/signature.js
+++ b/src/apis/request/signature.js
@@ -82,6 +82,22 @@ const postSignatureReComment = ({ signatureId, parentId, content }) => {
   });
 };
 
+// 시그니처 댓글/답글 수정하기
+const updateSignatureReComment = ({ signatureId, commentId, content }) => {
+  const url = `/api/v1/signature/${signatureId}/comment/${commentId}`;
+  console.log(url);
+  return axiosWithToken.patch(url, {
+    content: content,
+  });
+};
+
+// 시그니처 댓글/답글 삭제하기
+const deleteSignatureReComment = ({ signatureId, commentId }) => {
+  const url = `/api/v1/signature/${signatureId}/comment/${commentId}`;
+
+  return axiosWithToken.delete(url);
+};
+
 export {
   getMySignaturePreview,
   postNewSignature,
@@ -93,4 +109,6 @@ export {
   getSignatureComments,
   postSignatureComment,
   postSignatureReComment,
+  updateSignatureReComment,
+  deleteSignatureReComment,
 };

--- a/src/components/comment/signature/commentView/SignatureComment.jsx
+++ b/src/components/comment/signature/commentView/SignatureComment.jsx
@@ -1,27 +1,40 @@
 import { format } from 'date-fns';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import * as S from './SignatureComment.style';
 import Pen from '/icons/Pen.svg';
 import Trash from '/icons/Trash.svg';
 import Logo from '/images/mypage/MyPageLogo.svg';
-import { postSignatureReComment } from '@/apis/request/signature';
+import {
+  deleteSignatureReComment,
+  postSignatureReComment,
+  updateSignatureReComment,
+} from '@/apis/request/signature';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const SignatureComment = ({ data }) => {
   const { signatureId } = useParams();
-
   const queryClient = useQueryClient();
   const { _id, content, parentId, is_edited, writer, date } = data;
+
   const formattedEndDate = format(date, 'yyyy-MM-dd HH:mm:ss');
   const [editMode, setEditMode] = useState(false);
   const [isReplying, setIsReplying] = useState(false);
   const [replyComment, setReplyComment] = useState('');
-  console.log(replyComment);
+  const editModeRef = useRef(false);
+  const editedContentRef = useRef(content);
+  const inputRef = useRef(null);
 
-  const handleCommentEdit = () => {};
-  const handleCommentDelete = () => {};
+  useEffect(() => {
+    if (editModeRef.current) {
+      inputRef.current.focus();
+    }
+  }, [editModeRef.current]);
+
+  const handleContentChange = () => {
+    editedContentRef.current = inputRef.current.innerText;
+  };
 
   const indentationLevel = parentId === _id ? 0 : 1;
   const isParentComment = parentId === _id;
@@ -40,21 +53,79 @@ const SignatureComment = ({ data }) => {
     },
   });
 
+  const { mutateAsync: updateReComment } = useMutation({
+    mutationFn: updateSignatureReComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['signatureComments']);
+    },
+    onError: error => {
+      console.error('답글 수정 실패', error);
+    },
+  });
+
+  const { mutateAsync: deleteReComment } = useMutation({
+    mutationFn: deleteSignatureReComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['signatureComments']);
+    },
+    onError: error => {
+      console.error('답글 삭제 실패', error);
+    },
+  });
+
   return (
     <S.Container indentationLevel={indentationLevel}>
       <S.Avatar src={writer?.image ? writer?.image : Logo} />
       <S.ContentContainer>
         <S.NameContainer>
           <S.Name>{writer?.name}</S.Name>
-          {isParentComment && (
+          {writer?.is_writer === true && (
             <S.LeftContent>
               <S.Button onClick={handleReplyToggle}>답글</S.Button>
-              <S.Icon src={Pen} onClick={handleCommentEdit} />
-              <S.Icon src={Trash} onClick={handleCommentDelete} />
+              {editMode ? (
+                <button
+                  onClick={async () => {
+                    try {
+                      await updateReComment({
+                        signatureId,
+                        commentId: _id,
+                        content: editedContentRef.current,
+                      });
+                      setEditMode(false);
+                    } catch (e) {
+                      console.error(e);
+                    }
+                  }}>
+                  수정 완료
+                </button>
+              ) : (
+                <S.Icon
+                  src={Pen}
+                  onClick={() => {
+                    setEditMode(true);
+                  }}
+                />
+              )}
+              <S.Icon
+                src={Trash}
+                onClick={async () => {
+                  try {
+                    await deleteReComment({ signatureId, commentId: _id });
+                  } catch (e) {
+                    console.error(e);
+                  }
+                }}
+              />
             </S.LeftContent>
           )}
         </S.NameContainer>
-        <S.Content>{content}</S.Content>
+        <S.Content
+          contentEditable={editMode}
+          suppressContentEditableWarning={editMode}
+          ref={inputRef}
+          onInput={handleContentChange}>
+          {content}
+        </S.Content>
         <S.ContentInner>
           <S.Content>{formattedEndDate}</S.Content>
           <S.EditContent>{is_edited === true ? '수정됨' : null}</S.EditContent>

--- a/src/components/comment/signature/commentView/SignatureComment.jsx
+++ b/src/components/comment/signature/commentView/SignatureComment.jsx
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, formatDistance } from 'date-fns';
 import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -12,11 +12,18 @@ import {
   updateSignatureReComment,
 } from '@/apis/request/signature';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ko } from 'date-fns/locale';
 
 const SignatureComment = ({ data }) => {
   const { signatureId } = useParams();
   const queryClient = useQueryClient();
   const { _id, content, parentId, is_edited, writer, date } = data;
+
+  const currentTime = new Date();
+  const timeAgo = formatDistance(date, currentTime, {
+    addSuffix: true,
+    locale: ko,
+  });
 
   const formattedEndDate = format(date, 'yyyy-MM-dd HH:mm:ss');
   const [editMode, setEditMode] = useState(false);
@@ -127,7 +134,7 @@ const SignatureComment = ({ data }) => {
           {content}
         </S.Content>
         <S.ContentInner>
-          <S.Content>{formattedEndDate}</S.Content>
+          <S.Content>{timeAgo}</S.Content>
           <S.EditContent>{is_edited === true ? '수정됨' : null}</S.EditContent>
         </S.ContentInner>
         {isReplying && (

--- a/src/components/comment/signature/commentView/SignatureComment.jsx
+++ b/src/components/comment/signature/commentView/SignatureComment.jsx
@@ -46,10 +46,6 @@ const SignatureComment = ({ data }) => {
   const indentationLevel = parentId === _id ? 0 : 1;
   const isParentComment = parentId === _id;
 
-  const handleReplyToggle = () => {
-    setIsReplying(!isReplying);
-  };
-
   const { mutateAsync: postReComment } = useMutation({
     mutationFn: postSignatureReComment,
     onSuccess: () => {
@@ -88,23 +84,31 @@ const SignatureComment = ({ data }) => {
           <S.Name>{writer?.name}</S.Name>
           {writer?.is_writer === true && (
             <S.LeftContent>
-              <S.Button onClick={handleReplyToggle}>답글</S.Button>
+              {!editMode && (
+                <S.Button onClick={() => setIsReplying(true)}>답글</S.Button>
+              )}
+              {isReplying === true && (
+                <S.Button onClick={() => setIsReplying(false)}>취소</S.Button>
+              )}
               {editMode ? (
-                <button
-                  onClick={async () => {
-                    try {
-                      await updateReComment({
-                        signatureId,
-                        commentId: _id,
-                        content: editedContentRef.current,
-                      });
-                      setEditMode(false);
-                    } catch (e) {
-                      console.error(e);
-                    }
-                  }}>
-                  수정 완료
-                </button>
+                <>
+                  <S.Button
+                    onClick={async () => {
+                      try {
+                        await updateReComment({
+                          signatureId,
+                          commentId: _id,
+                          content: editedContentRef.current,
+                        });
+                        setEditMode(false);
+                      } catch (e) {
+                        console.error(e);
+                      }
+                    }}>
+                    수정 완료
+                  </S.Button>
+                  <S.Button onClick={() => setEditMode(false)}>취소</S.Button>
+                </>
               ) : (
                 <S.Icon
                   src={Pen}

--- a/src/components/comment/signature/commentView/SignatureComment.jsx
+++ b/src/components/comment/signature/commentView/SignatureComment.jsx
@@ -25,7 +25,6 @@ const SignatureComment = ({ data }) => {
     locale: ko,
   });
 
-  const formattedEndDate = format(date, 'yyyy-MM-dd HH:mm:ss');
   const [editMode, setEditMode] = useState(false);
   const [isReplying, setIsReplying] = useState(false);
   const [replyComment, setReplyComment] = useState('');
@@ -34,10 +33,10 @@ const SignatureComment = ({ data }) => {
   const inputRef = useRef(null);
 
   useEffect(() => {
-    if (editModeRef.current) {
+    if (editMode) {
       inputRef.current.focus();
     }
-  }, [editModeRef.current]);
+  }, [editMode]);
 
   const handleContentChange = () => {
     editedContentRef.current = inputRef.current.innerText;
@@ -158,6 +157,7 @@ const SignatureComment = ({ data }) => {
                     content: replyComment,
                   });
                   setReplyComment('');
+                  setIsReplying(false);
                 } catch (e) {
                   console.log(e);
                 }

--- a/src/components/comment/signature/commentView/SignatureComment.style.js
+++ b/src/components/comment/signature/commentView/SignatureComment.style.js
@@ -30,7 +30,6 @@ const Button = styled.button`
   border: none;
   padding: 5px 10px;
   border-radius: 10px;
-  margin-left: 10px;
   cursor: pointer;
 
   &:hover {
@@ -86,8 +85,7 @@ const NameContainer = styled.div`
 `;
 
 const LeftContent = styled.div`
-  display: flex;
-  flex-direction: row;
+  ${theme.ALIGN.ROW_CENTER};
   gap: 5px;
   margin-left: auto;
 `;
@@ -95,8 +93,11 @@ const LeftContent = styled.div`
 const Icon = styled.img`
   display: flex;
   width: 15px;
-  height: 15px;
   cursor: pointer;
+
+  &:hover {
+    transform: scale(0.9);
+  }
 `;
 
 export {

--- a/src/pages/signature/post/SignaturePost.jsx
+++ b/src/pages/signature/post/SignaturePost.jsx
@@ -159,17 +159,13 @@ const SignaturePostPage = () => {
               <S.PageCount>
                 {step}/{totalPages}
               </S.PageCount>
-              {author?.is_followed !== null && (
-                <S.FunctionButtonContainer>
-                  <S.ModifyButton
-                    onClick={() => navigate(`/signature/edit/${signatureId}`)}>
-                    수정
-                  </S.ModifyButton>
-                  <S.DeleteButton onClick={handleDeletePost}>
-                    삭제
-                  </S.DeleteButton>
-                </S.FunctionButtonContainer>
-              )}
+              <S.FunctionButtonContainer>
+                <S.ModifyButton
+                  onClick={() => navigate(`/signature/edit/${signatureId}`)}>
+                  수정
+                </S.ModifyButton>
+                <S.DeleteButton onClick={handleDeletePost}>삭제</S.DeleteButton>
+              </S.FunctionButtonContainer>
             </>
             <S.CommentContainer>
               <SignatureCommentInput />


### PR DESCRIPTION
### 요약
1. 시그니처 페이지 대댓글 수정 삭제 API 연결 및 기능 개발.
2. 시그니처 페이지 대댓글 스타일링 및 UX 개선
3. 대댓글, 몇초전에 작성한 댓글인지 수정 여부 표시



### 구현
<시그니처 페이지 UX 개선>
<img width="690" alt="스크린샷 2024-02-14 오전 5 15 04" src="https://github.com/Here-You/FrontEnd/assets/119042360/37feeefd-d878-463a-b7c4-ddbe66b5f789">




### 개발 현황
요약 완성.

### 참고 사항
나의 뇌...
유정님 API랑, 기능 의견 감사합니다..!