### PR TITLE
[FEAT]: Signature Post, Comment 로그인 로직 수정

### DIFF
--- a/src/components/comment/signature/commentInput/SignatureCommentInput.jsx
+++ b/src/components/comment/signature/commentInput/SignatureCommentInput.jsx
@@ -1,12 +1,17 @@
-import { useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import * as S from './SignatureInput.style';
+import Logo from '/images/mypage/MyPageLogo.svg';
 import { postSignatureComment } from '@/apis/request/signature';
+import { useGetMyProfile } from '@/hooks/profile/queries/useGetMyProfile';
+import useAuth from '@/store/useAuth';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const SignatureCommentInput = () => {
+  const { isLogin } = useAuth();
   const [content, setContent] = useState('');
+  const navigate = useNavigate();
 
   const { signatureId } = useParams();
   const queryClient = useQueryClient();
@@ -22,31 +27,44 @@ const SignatureCommentInput = () => {
       );
     },
   });
+  const {
+    data: me,
+    isPending: mePending,
+    isError: meError,
+  } = useGetMyProfile();
+
+  const myProfile = me?.data?.data?.user?.profileImage;
+
   const placeholder = '댓글을 작성해주세요';
-  const imgUrl =
-    'https://images.unsplash.com/photo-1707421940727-ebfb88cd6aa0?q=80&w=2232&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
+
   return (
     <S.Container>
-      <S.Avatar src={imgUrl} />
-      <S.ContentContainer>
-        <S.Input
-          placeholder={placeholder}
-          value={content}
-          onChange={e => setContent(e.target.value)}
-          rows={1}
-        />
-        <S.SubmitButton
-          onClick={async () => {
-            try {
-              await mutateAsync({ signatureId, content });
-              setContent('');
-            } catch (e) {
-              console.error(e);
-            }
-          }}>
-          저장
-        </S.SubmitButton>
-      </S.ContentContainer>
+      {isLogin ? (
+        <>
+          <S.Avatar src={myProfile || Logo} />
+          <S.ContentContainer>
+            <S.Input
+              placeholder={placeholder}
+              value={content}
+              onChange={e => setContent(e.target.value)}
+              rows={1}
+            />
+            <S.SubmitButton
+              onClick={async () => {
+                try {
+                  await mutateAsync({ signatureId, content });
+                  setContent('');
+                } catch (error) {
+                  console.error('댓글 작성 실패:', error);
+                }
+              }}>
+              저장
+            </S.SubmitButton>
+          </S.ContentContainer>
+        </>
+      ) : (
+        <div onClick={() => navigate('/login')}>로그인을 해주세요</div>
+      )}
     </S.Container>
   );
 };

--- a/src/components/comment/signature/commentView/SignatureComment.jsx
+++ b/src/components/comment/signature/commentView/SignatureComment.jsx
@@ -1,4 +1,4 @@
-import { format, formatDistance } from 'date-fns';
+import { formatDistance } from 'date-fns';
 import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -17,7 +17,7 @@ import { ko } from 'date-fns/locale';
 const SignatureComment = ({ data }) => {
   const { signatureId } = useParams();
   const queryClient = useQueryClient();
-  const { _id, content, parentId, is_edited, writer, date } = data;
+  const { _id, content, parentId, is_edited, writer, date, can_delete } = data;
 
   const currentTime = new Date();
   const timeAgo = formatDistance(date, currentTime, {
@@ -81,7 +81,7 @@ const SignatureComment = ({ data }) => {
       <S.ContentContainer>
         <S.NameContainer>
           <S.Name>{writer?.name}</S.Name>
-          {writer?.is_writer === true && (
+          {(can_delete || writer?.is_writer) && (
             <S.LeftContent>
               {!editMode && (
                 <S.Button onClick={() => setIsReplying(true)}>답글</S.Button>

--- a/src/pages/signature/post/SignaturePost.jsx
+++ b/src/pages/signature/post/SignaturePost.jsx
@@ -10,6 +10,7 @@ import SignatureCommentInput from '@/components/comment/signature/commentInput/S
 import FollowButton from '@/components/mate/FollowButton';
 import LikerFindModal from '@/components/modal/likerFindModal/LikerFindModal';
 import useLikersModal from '@/hooks/modal/useLikersModal';
+import { useGetMyProfile } from '@/hooks/profile/queries/useGetMyProfile';
 import { useGetSignaturePost } from '@/hooks/signature/queries/useGetSignaturePost';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { CiLocationOn } from 'react-icons/ci';
@@ -23,6 +24,13 @@ const SignaturePostPage = () => {
   const queryClient = useQueryClient();
 
   const { data, isPending, isError } = useGetSignaturePost(signatureId);
+  const {
+    data: me,
+    isPending: mePending,
+    isError: meError,
+  } = useGetMyProfile();
+
+  const isMine = me?.data?.data?.user?.id === data?.data?.data?.author?._id;
 
   const { mutateAsync } = useMutation({
     mutationFn: likeSignature,
@@ -159,13 +167,17 @@ const SignaturePostPage = () => {
               <S.PageCount>
                 {step}/{totalPages}
               </S.PageCount>
-              <S.FunctionButtonContainer>
-                <S.ModifyButton
-                  onClick={() => navigate(`/signature/edit/${signatureId}`)}>
-                  수정
-                </S.ModifyButton>
-                <S.DeleteButton onClick={handleDeletePost}>삭제</S.DeleteButton>
-              </S.FunctionButtonContainer>
+              {isMine && (
+                <S.FunctionButtonContainer>
+                  <S.ModifyButton
+                    onClick={() => navigate(`/signature/edit/${signatureId}`)}>
+                    수정
+                  </S.ModifyButton>
+                  <S.DeleteButton onClick={handleDeletePost}>
+                    삭제
+                  </S.DeleteButton>
+                </S.FunctionButtonContainer>
+              )}
             </>
             <S.CommentContainer>
               <SignatureCommentInput />


### PR DESCRIPTION
## 개요
이 PR은 Signature Post 및 Comment 컴포넌트의 로그인 로직을 수정하고 개선합니다.

## 변경 사항
- Signature Post 및 Comment 컴포넌트에서 로그인 여부를 확인하여 적절한 UI를 표시합니다.
- 로그인한 사용자에게는 작성자 또는 댓글 삭제 기능을 허용합니다.
- 게시글의 주인인경우, 모든 댓글의 삭제 / 수정 권한이 허용됩니다.
- 댓글의 주인인 경우(다른사람 포스트의) 본인 댓글만 수정 삭제가 가능합니다.

## 작업 이미지

<img width="552" alt="스크린샷 2024-02-15 오전 5 29 08" src="https://github.com/Here-You/FrontEnd/assets/119042360/80b57f97-98de-48be-8973-288d9be666cc">

## 기타
