### PR TITLE
Feat: 캘린더 여정 작성 로직 및 스타일 수정

### DIFF
--- a/src/components/calendar/TravelCalendar.jsx
+++ b/src/components/calendar/TravelCalendar.jsx
@@ -6,8 +6,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import SchedulesView from '../schedules/SchedulesView';
 import * as S from './TravelCalendar.style';
 import CalendarSkeleton from './skeleton/CalendarSkeleton';
+import EditLight from '/icons/EditLight.svg';
 import { useMonthlyJourney } from '@/hooks/home/useMonthlyJourney';
-import { ErrorPage } from '@/pages';
 
 moment.locale('en');
 
@@ -17,8 +17,18 @@ const TravelCalendar = ({
   setJourneyInfo,
   setMonthlyInfo,
 }) => {
-  const [startDate, setStartDate] = useState(new Date());
-  const [endDate, setEndDate] = useState(new Date());
+  const storedStartDate = localStorage.getItem('startDate');
+  const storedEndDate = localStorage.getItem('endDate');
+
+  const [startDate, setStartDate] = useState(() => {
+    const storedStartDate = localStorage.getItem('startDate');
+    return storedStartDate ? storedStartDate : new Date();
+  });
+  const [endDate, setEndDate] = useState(() => {
+    const storedEndDate = localStorage.getItem('endDate');
+    return storedEndDate ? storedEndDate : new Date();
+  });
+  const [journeyTitle, setJourneyTitle] = useState('');
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
@@ -31,6 +41,9 @@ const TravelCalendar = ({
   } = useMonthlyJourney(year, month);
 
   useEffect(() => {
+    const storedStartDate = localStorage.getItem('startDate');
+    const storedEndDate = localStorage.getItem('endDate');
+
     if (data) {
       data &&
         data.forEach(monthlyJourney => {
@@ -41,6 +54,12 @@ const TravelCalendar = ({
               endDate: monthlyJourney.endDate,
             },
           ]);
+          if (
+            storedStartDate === monthlyJourney.startDate &&
+            storedEndDate === monthlyJourney.endDate
+          ) {
+            setJourneyTitle(monthlyJourney.title);
+          }
         });
     }
   }, [data, setMonthlyInfo]);
@@ -57,6 +76,8 @@ const TravelCalendar = ({
     const endDateFormatFind = moment(e[1]).format('YYYY-MM-DD');
 
     if (startDateFormatFind && endDateFormatFind) {
+      localStorage.setItem('startDate', startDateFormatFind);
+      localStorage.setItem('endDate', endDateFormatFind);
       if (data) {
         const foundJourney = data.find(
           journeydata =>
@@ -65,8 +86,10 @@ const TravelCalendar = ({
         );
         if (foundJourney) {
           setJourneyInfo(foundJourney);
+          setJourneyTitle(foundJourney.title);
         } else {
           setJourneyInfo(null);
+          setJourneyTitle('');
         }
       }
     }
@@ -134,8 +157,44 @@ const TravelCalendar = ({
               formatDay={(locale, date) => moment(date).format('D')}
               selectRange={true}
             />
+            <S.IntroductionContainer>
+              {storedStartDate && storedEndDate ? (
+                <>
+                  <S.JouneyInfoContainer>
+                    {journeyTitle ? (
+                      <p>🏖️ 선택된 여정 : {journeyTitle}</p>
+                    ) : (
+                      <p>새로운 여정을 추가하고 여행 일정을 생성하세요!</p>
+                    )}
 
-            <SchedulesView startDate={startDate} endDate={endDate} />
+                    <p>
+                      {startDate} ~ {endDate}
+                    </p>
+                  </S.JouneyInfoContainer>
+                  <S.JouneyInfoContainer>
+                    <h3>
+                      Tip.{'\t'}
+                      <span>
+                        일지 작성 <S.Image src={EditLight} />
+                      </span>
+                      버튼을 눌러 일지를 작성하면 지도에서
+                      <br />
+                      이미지로 표시된 위치를 확인할 수 있습니다.
+                    </h3>
+                  </S.JouneyInfoContainer>
+                </>
+              ) : (
+                <p>
+                  달력에서 기간을 선택하면 저장된 일정을 확인할 수 있습니다.
+                </p>
+              )}
+            </S.IntroductionContainer>
+
+            <SchedulesView
+              startDate={startDate}
+              endDate={endDate}
+              journeyTitle={journeyTitle}
+            />
           </S.HomeContentContainer>
         </S.Wrapper>
       )}

--- a/src/components/calendar/TravelCalendar.style.js
+++ b/src/components/calendar/TravelCalendar.style.js
@@ -105,7 +105,7 @@ const Circle = styled.div`
 
 const HomeContentContainer = styled.div`
   ${theme.ALIGN.COLUMN_CENTER};
-  gap: 50px;
+  gap: 40px;
 `;
 
 const SchedulesContainer = styled.div`
@@ -123,6 +123,59 @@ const SchedulesContainer = styled.div`
   }
 `;
 
+const IntroductionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  width: 90%;
+  padding: 20px;
+  background-color: ${theme.COLOR.MAIN.LIGHT_GREEN};
+  border-radius: 10px;
+`;
+
+const JouneyInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+
+  p {
+    color: ${theme.COLOR.MAIN.BLACK};
+    font-size: ${FONT_SIZE.LG};
+    font-family: 'Pretendard-semibold';
+  }
+
+  h3 {
+    color: ${theme.COLOR.MAIN.GRAY};
+    font-size: ${FONT_SIZE.SM};
+    font-family: 'Pretendard-semibold';
+  }
+
+  h3 span {
+    color: ${theme.COLOR.MAIN.BLACK};
+    font-size: ${FONT_SIZE.SM};
+    font-family: 'Pretendard-semibold';
+  }
+
+  @media ${theme.WINDOW_SIZE.MOBILE} {
+    p {
+      font-size: ${FONT_SIZE.BASE};
+    }
+
+    h3 {
+      font-size: ${FONT_SIZE.XS};
+    }
+
+    h3 span {
+      font-size: ${FONT_SIZE.XS};
+    }
+  }
+`;
+
+const Image = styled.img`
+  width: 15px;
+`;
+
 export {
   HighlightedElement,
   Wrapper,
@@ -134,4 +187,7 @@ export {
   Circle,
   HomeContentContainer,
   SchedulesContainer,
+  IntroductionContainer,
+  JouneyInfoContainer,
+  Image,
 };

--- a/src/components/modal/journeyEdit/JourneyEditModal.jsx
+++ b/src/components/modal/journeyEdit/JourneyEditModal.jsx
@@ -84,6 +84,8 @@ const JourneyEditModal = ({ journeyId, journeyTitle, startDate, endDate }) => {
     try {
       const res = await deleteJourney(journeyId);
       if (res) toast.success('여정이 삭제되었습니다.');
+      localStorage.removeItem('startDate');
+      localStorage.removeItem('endDate');
       window.location.reload();
     } catch (error) {
       setIsError(true);

--- a/src/components/schedules/SchedulesView.jsx
+++ b/src/components/schedules/SchedulesView.jsx
@@ -9,11 +9,10 @@ import SchedulesViewSkeleton from './skeleton/SchedulesViewSkeleton';
 import { getSchedule } from '@/apis/request/home';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-const SchedulesView = ({ startDate, endDate }) => {
+const SchedulesView = ({ startDate, endDate, journeyTitle }) => {
   const accessToken = localStorage.getItem('x-access-token');
   const pageSize = 5;
   const date = new Date(startDate);
-  const isStartDateDateInstance = startDate instanceof Date;
 
   const formattedDate = format(date, 'yyyy-MM-dd');
 
@@ -55,8 +54,10 @@ const SchedulesView = ({ startDate, endDate }) => {
 
   return (
     <>
-      {isLoading && new Array(3).fill(0).map(item => <SchedulesViewSkeleton />)}
-      {!isLoading && !isStartDateDateInstance && (
+      {isLoading &&
+        journeyTitle &&
+        new Array(3).fill(0).map(item => <SchedulesViewSkeleton />)}
+      {!isLoading && journeyTitle && (
         <S.Container $showContainer={dataExists}>
           {schedulesData?.pages?.map((page, pageIndex) =>
             page?.data?.data?.data?.paginatedSchedules.map(scheduleData => (
@@ -77,13 +78,13 @@ const SchedulesView = ({ startDate, endDate }) => {
           <S.IntroMessage>로그인 후 여정을 작성해보세요!</S.IntroMessage>
         </Link>
       )}
-
+      {/* 
       {!isLoading && accessToken && !dataExists && (
         <div>아직 작성한 여정이 없어요!</div>
       )}
-      {!isLoading && accessToken && dataExists && isStartDateDateInstance && (
+      {!isLoading && accessToken && dataExists && journeyTitle && (
         <div>달력에서 기간을 선택하고, 일정을 확인하세요!</div>
-      )}
+      )} */}
     </>
   );
 };

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import * as S from './Home.style';
@@ -14,6 +14,9 @@ const HomePage = () => {
   const accessToken = localStorage.getItem('x-access-token');
   const journeyWriteModal = useJourneyWriteModal();
   const journeyEditModal = useJourneyEditModal();
+  const [isCreateSelected, setIsCreateSelected] = useState(false);
+  const [isEditSelected, setIsEditSelected] = useState(false);
+
   const [isClicked, setIsClicked] = useState(false);
   const [startDate, setStateDate] = useState('');
   const [endDate, setEndDate] = useState('');
@@ -88,9 +91,20 @@ const HomePage = () => {
     }
   };
 
-  const handleClickAddButton = () => {
-    setIsClicked(!isClicked);
-  };
+  useEffect(() => {
+    if ((startDate, endDate)) {
+      const res = checkOverlap(startDate, endDate, monthlyInfo);
+      if (res) {
+        setIsEditSelected(true);
+        setIsClicked(true);
+        setIsCreateSelected(false);
+      } else {
+        setIsCreateSelected(true);
+        setIsClicked(true);
+        setIsEditSelected(false);
+      }
+    }
+  }, [startDate, endDate, monthlyInfo]);
 
   return (
     <S.Container $dataLength={testData.length}>
@@ -109,22 +123,22 @@ const HomePage = () => {
         startDate={journeyInfo?.startDate}
         endDate={journeyInfo?.endDate}
       />
-      <S.JourneyButtonContainer>
-        <S.EditButton $isClicked={isClicked} onClick={handleEditJourney}>
-          여정 확인 및 수정
-        </S.EditButton>
-        <S.VerticalLine $isClicked={isClicked} $browserName={browserName}>
-          |
-        </S.VerticalLine>
-        <S.WriteButton onClick={handleAddJourney} $isClicked={isClicked}>
-          새 여정 추가하기
-        </S.WriteButton>
-        <S.AddButton
-          onClick={handleClickAddButton}
-          $isClicked={isClicked}
-          $browserName={browserName}>
-          +
-        </S.AddButton>
+      <S.JourneyButtonContainer $isClicked={isClicked}>
+        {isEditSelected ? (
+          <S.EditButton
+            onClick={handleEditJourney}
+            $isClicked={isClicked}
+            $isEditSelected={isEditSelected}>
+            {isEditSelected && '✈️'} 여정 확인 및 수정
+          </S.EditButton>
+        ) : (
+          <S.WriteButton
+            onClick={handleAddJourney}
+            $isClicked={isClicked}
+            $isCreateSelected={isCreateSelected}>
+            {isCreateSelected && '✈️'} 새 여정 추가하기
+          </S.WriteButton>
+        )}
       </S.JourneyButtonContainer>
     </S.Container>
   );

--- a/src/pages/home/Home.style.js
+++ b/src/pages/home/Home.style.js
@@ -1,7 +1,19 @@
-import styled from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 
 import { FONT_SIZE } from '@/constants/size';
 import theme from '@/theme';
+
+const popAnimation = keyframes`
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+`;
 
 const Container = styled.div`
   ${theme.ALIGN.COLUMN_CENTER}
@@ -57,92 +69,52 @@ const JourneyButtonContainer = styled.div`
   cursor: pointer;
   z-index: 1;
   align-self: flex-end;
+
+  transition: all 0.3s ease;
+  ${props =>
+    props.$isClicked &&
+    css`
+      animation: ${popAnimation} 0.3s ease;
+    `}
 `;
 
 const EditButton = styled.button`
-  visibility: ${props => (props.$isClicked ? 'visible' : 'hidden')};
+  padding: 20px;
+  border: 1px solid ${theme.COLOR.MAIN.GREEN};
+  color: ${props =>
+    props.$isEditSelected
+      ? `${theme.COLOR.MAIN.GREEN}`
+      : `${theme.COLOR.MAIN.BLACK}`};
 
-  padding: 25px 30px;
-  border-top: 1px solid ${theme.COLOR.MAIN.GREEN};
-  border-left: 1px solid ${theme.COLOR.MAIN.GREEN};
-  border-bottom: 1px solid ${theme.COLOR.MAIN.GREEN};
-  border-right: 0px;
-
-  border-top-left-radius: 100px;
-  border-bottom-left-radius: 100px;
-
+  border-radius: 100px;
+  @media ${theme.WINDOW_SIZE.MOBILE} {
+    padding: 10px;
+  }
   background-color: ${theme.COLOR.MAIN.WHITE};
   cursor: pointer;
-  &:hover {
-    color: ${theme.COLOR.MAIN.GREEN};
-  }
-
-  @media ${theme.WINDOW_SIZE.MOBILE} {
-    padding: 20px 15px;
-  }
+  transition: all 0.3s ease;
+  animation: ${popAnimation} 0.3s ease;
 `;
 
 const WriteButton = styled.button`
-  visibility: ${props => (props.$isClicked ? 'visible' : 'hidden')};
-
-  padding: 10px 80px 10px 30px;
-  border-top: 1px solid ${theme.COLOR.MAIN.GREEN};
-  border-right: 1px solid ${theme.COLOR.MAIN.GREEN};
-  border-bottom: 1px solid ${theme.COLOR.MAIN.GREEN};
-  border-left: 0px;
-  border-top-right-radius: 100px;
-  border-bottom-right-radius: 100px;
+  padding: 20px;
+  border: 1px solid ${theme.COLOR.MAIN.GREEN};
+  border-radius: 100px;
+  color: ${props =>
+    props.$isCreateSelected
+      ? `${theme.COLOR.MAIN.GREEN}`
+      : `${theme.COLOR.MAIN.BLACK}`};
 
   background-color: ${theme.COLOR.MAIN.WHITE};
   cursor: pointer;
   &:hover {
     color: ${theme.COLOR.MAIN.GREEN};
   }
-
   @media ${theme.WINDOW_SIZE.MOBILE} {
-    padding: 10px 60px 10px 30px;
+    padding: 10px;
   }
-`;
-
-const AddButton = styled.button`
-  position: absolute;
-  ${theme.ALIGN.COLUMN_CENTER};
-  padding: 0 0 5px 0;
-  width: 50px;
-  height: 50px;
-  top: 10px;
-  left: 310px;
-
-  text-align: center;
-  background-color: #e8f6ef;
-  border: none;
-  border-radius: 50%;
-  color: ${theme.COLOR.MAIN.GREEN};
-  font-size: ${FONT_SIZE.FOUR_XL};
-
-  cursor: pointer;
-  transform: ${({ $isClicked }) => ($isClicked ? 'rotate(-45deg)' : 'none')};
-  transition: transform 0.3s ease;
-
-  @media ${theme.WINDOW_SIZE.MOBILE} {
-    width: 40px;
-    height: 40px;
-    left: ${props => (props.$browserName === 'safari' ? '265px' : '270px')};
-  }
-`;
-
-const VerticalLine = styled.p`
-  visibility: ${props => (props.$isClicked ? 'visible' : 'hidden')};
-  position: absolute;
-  top: 25px;
-  left: 170px;
-  color: ${theme.COLOR.MAIN.GREEN};
-  font-size: ${FONT_SIZE.XL};
-
-  @media ${theme.WINDOW_SIZE.MOBILE} {
-    top: 18px;
-    left: ${props => (props.$browserName === 'safari' ? '150px' : '145px')};
-  }
+  transition: all 0.3s ease;
+  animation: ${popAnimation} 0.3s ease;
 `;
 
 const JourneyWrapper = styled.div``;
@@ -158,9 +130,7 @@ export {
   ButtonContainer,
   Button,
   MapContainer,
-  AddButton,
   JourneyButtonContainer,
   EditButton,
   WriteButton,
-  VerticalLine,
 };


### PR DESCRIPTION
## 구현 내용
- [x] 달력에서 날짜 선택 시 바로 여정 추가 및 수정을 유도할 수 있도록 애니메이션 구현
- [x] 여정을 추가하거나 삭제할 시, 새로 화면이 뜰 때 해당 날짜가 선택되어 일정을 하단에 보여준다. 
- [x] (bug) 처음 캘린더 화면 뜰 때, 스켈레톤 UI 나타나는 오류 수정
- [x] 캘린더 밑에 선택된 여정 정보(기간, 여정 제목)와 간단한 캘린더, 맵의 서비스 소개를 보여준다. (배너처럼)

## 구현 화면
1. 이미 저장된 여정 선택 시
![image](https://github.com/Here-You/FrontEnd/assets/104924817/1a3f0686-d14c-4596-a233-391138e3a7f6)

2. 여정 저장이 안된 기간 선택 시
![image](https://github.com/Here-You/FrontEnd/assets/104924817/e5648eb2-321f-4e71-9ca7-0784cb4a8e98)

3. 페이지 가장 처음 들어갔을 때 (기간 선택 한 적 없을 때)
![image](https://github.com/Here-You/FrontEnd/assets/104924817/c356c188-d22e-4a1a-b642-4af9d5483993)
